### PR TITLE
add agent_args option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The `vagrant-rancher` plugin requires the hostname being set to either a DNS nam
 * `port` (*optional*, default: `8080`): port to run the rancher server on in the case of the server, and communicate with in the case of the agent
 * `rancher_server_image` (*optional*, default: `rancher/server`): Override default Rancher server image name. Allows for pull from a private registry
 * `server_args` (*optional*, default: `''`): additional args to pass to the Docker run command when starting the Rancher server
+* `agent_args` (*optional*, default: `''`): additional args to pass to the Docker run command when starting the Rancher agent
 * `install_agent` (*optional*, default: `true`): install rancher-agent on guest
 * `labels` (*optional*, default: `[]`): array of key=value pairs of labels to assign to the agent (ex. ["role=server","env=local"])
 * `deactivate` (*optional*, default: `false`): deactivate the host in Rancher to prevent it from being scheduled on

--- a/lib/vagrant-rancher/config.rb
+++ b/lib/vagrant-rancher/config.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
       attr_accessor :deactivate
       attr_accessor :rancher_server_image
       attr_accessor :server_args
+      attr_accessor :agent_args
       attr_accessor :install_agent
       attr_accessor :labels
       attr_accessor :project
@@ -20,6 +21,7 @@ module VagrantPlugins
         @port = UNSET_VALUE
         @rancher_server_image = UNSET_VALUE
         @server_args = UNSET_VALUE
+        @agent_args = UNSET_VALUE
         @install_agent = UNSET_VALUE
         @labels = UNSET_VALUE
         @deactivate = UNSET_VALUE
@@ -34,6 +36,7 @@ module VagrantPlugins
         @port = 8080 if @port == UNSET_VALUE
         @rancher_server_image = 'rancher/server' if @rancher_server_image == UNSET_VALUE
         @server_args = nil if @server_args == UNSET_VALUE
+        @agent_args = nil if @agent_args == UNSET_VALUE
         @install_agent = true if @install_agent == UNSET_VALUE
         @labels = nil if @labels == UNSET_VALUE
         @deactivate = false if @deactivate == UNSET_VALUE
@@ -66,6 +69,10 @@ module VagrantPlugins
 
         unless server_args.is_a?(String) || server_args.nil?
           errors << ':rancher provisioner requires server_args to be a string'
+        end
+
+        unless agent_args.is_a?(String) || agent_args.nil?
+          errors << ':rancher provisioner requires agent_args to be a string'
         end
 
         unless install_agent.is_a?(TrueClass) || install_agent.is_a?(FalseClass)

--- a/lib/vagrant-rancher/provisioner.rb
+++ b/lib/vagrant-rancher/provisioner.rb
@@ -152,6 +152,11 @@ module VagrantPlugins
           extra_args = "-e 'CATTLE_HOST_LABELS=#{labels}' --name rancher-agent-bootstrap"
           docker_cmd = docker_cmd.sub('docker run', "docker run #{extra_args}")
 
+          # add any user supplied args to the docker command
+          unless config.agent_args.nil?
+            docker_cmd = "#{docker_cmd} #{config.agent_args}"
+          end
+
           # pull rancher agent image if its not already there
           image_check_cmd = "sudo docker images | awk '{ print $1\":\"$2 }' | grep -q #{registration_token['image']}"
           unless @machine.communicate.test(image_check_cmd)

--- a/lib/vagrant-rancher/provisioner.rb
+++ b/lib/vagrant-rancher/provisioner.rb
@@ -150,12 +150,11 @@ module VagrantPlugins
           end
 
           extra_args = "-e 'CATTLE_HOST_LABELS=#{labels}' --name rancher-agent-bootstrap"
-          docker_cmd = docker_cmd.sub('docker run', "docker run #{extra_args}")
-
-          # add any user supplied args to the docker command
           unless config.agent_args.nil?
-            docker_cmd = "#{docker_cmd} #{config.agent_args}"
+            extra_args = "#{extra_ags} #{config.agent_args}"
           end
+
+          docker_cmd = docker_cmd.sub('docker run', "docker run #{extra_args}")
 
           # pull rancher agent image if its not already there
           image_check_cmd = "sudo docker images | awk '{ print $1\":\"$2 }' | grep -q #{registration_token['image']}"

--- a/lib/vagrant-rancher/provisioner.rb
+++ b/lib/vagrant-rancher/provisioner.rb
@@ -151,7 +151,7 @@ module VagrantPlugins
 
           extra_args = "-e 'CATTLE_HOST_LABELS=#{labels}' --name rancher-agent-bootstrap"
           unless config.agent_args.nil?
-            extra_args = "#{extra_ags} #{config.agent_args}"
+            extra_args = "#{extra_args} #{config.agent_args}"
           end
 
           docker_cmd = docker_cmd.sub('docker run', "docker run #{extra_args}")


### PR DESCRIPTION
agent_args works similarly to server_args.  Handy for using `--add-host` to the
docker command so you can use DNS with a the hostmanager plugin